### PR TITLE
[PLATFORM-408]: [Backstage] Add better documentation for our services

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+spec:
+  type: library
+  lifecycle: production
+  owner: team-shared-services
+  system: prima.it
+metadata:
+  name: localauth0
+  description: Auth0 docker image for local development. Inspired by localstack.
+  tags:
+    - rust
+    - wasm
+    - pyxis
+  links: []


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-408

This PR proposes to add the `catalog-info.yaml` file to expose this service on Backstage.

Let me know if it makes sense

