### PR TITLE
PG-526/task/add auth code flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extend `/oauth/token` endpoint content type compatibility with `application/x-www-form-urlencoded`.
+- Added `/oauth/login` endpoint to support authentication with `response_type: code`.
+- Grant type field added to claims with values `client_credentials` and `authorization_code`.
+
 ## [0.3.0] - 2022-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Here it's possible to:
     "grant_type": "client_credentials"
   }
   ```
+  for the client credentials grant and
+
+  ```json
+  {
+    "client_id": "client_id",
+    "client_secret": "client_secret",
+    "grant_type": "authorization_code",
+    "code": "{{your-auth-code}}"
+  }
+  ```
+  for the authorization code grant.
 
 - `GET` <http://localhost:3000/permissions>: used to get a the list of all audiences with their associated permissions.
 
@@ -77,8 +88,10 @@ Localauth0 could behave like Google SSO page. In order to achieve this your web 
 
 - redirect_uri: your web app callback page
 - audience: the audience you want to use to generate the token
-- response_type (optional): could be `token` or `code`. Actually only `token` is provided and is used by default. 
-  This option mean that after the redirect the url will contain the `access_token` in query string.  
+- response_type (optional): could be `token` or `code`. Use `token` to perform an implicit grant flow
+  and retrieve an access token directly and use `code` to perform an authorization code flow and recieve
+  an authorization code. If auth is succesful, the requested redirect is performed with the code or token contained
+  in the query params.
 - state (optional): An opaque value, used for security purposes. If this request parameter is set in the request, 
   then it is returned to the application as part of the `redirect_uri`.
 - bypass (optional): this is a dev feature. If set to true directly redirect to `redirect_uri`.
@@ -91,7 +104,7 @@ After redirection the redirect_url will contain these http fragments:
 
 For example navigating to:
 
-<http://localhost:3000/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&audience=audience1&client_id=whatever&connection=whatever&response_type=token&scope=whatever&state=test-state&bypass=true>
+<http://localhost:3000/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&audience=audience1&client_id=client_id&connection=whatever&response_type=token&scope=whatever&state=test-state&bypass=true>
 
 The page will automatically redirect to:
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,12 +18,13 @@ pub async fn jwks(app_data: Data<AppData>) -> HttpResponse {
         .body(serde_json::to_string(&jwks).expect("Failed to serialize JWKS to json"))
 }
 
-/// Handler for json body posts to the token endpoint
+/// Handler for application/json encoded post bodies to the token endpoint
 pub async fn jwt_json_body_handler(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> HttpResponse {
     jwt(app_data, token_request.0).await
 }
 
-/// Handler for url form encoded posts to the token endpoint
+/// Handler for application/x-www-form-urlencoded encoded post bodies to the token endpoint.
+/// This is the required format specified by `https://www.rfc-editor.org/rfc/rfc6749#section-4.4.2`. and auth0
 pub async fn jwt_form_body_handler(app_data: Data<AppData>, token_request: Form<TokenRequest>) -> HttpResponse {
     jwt(app_data, token_request.0).await
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -31,7 +31,7 @@ pub async fn jwt_form_body_handler(app_data: Data<AppData>, token_request: Form<
 
 /// Generate a new jwt token for a given audience. For `client_credentials` the audience is found in the post body
 /// and for `authorization_code` the audience is found in the authorizations cache.
-///  All the permissions found in the local store will be included in the generated token.
+/// All the permissions found in the local store will be included in the generated token.
 async fn jwt(app_data: Data<AppData>, token_request: TokenRequest) -> HttpResponse {
     match token_request {
         TokenRequest::ClientCredentials(request) => jwt_for_client_credentials(app_data, request).await,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
-use actix_web::web::{Data, Json, Path};
+use actix_web::web::{Data, Form, Json, Path};
 use actix_web::{get, post, HttpResponse};
 
-use crate::model::{AppData, Claims, Jwk, Jwks, PermissionsForAudienceRequest, TokenRequest, TokenResponse};
+use crate::model::{
+    AppData, AuthorizationCodeTokenRequest, Claims, ClientCredentialsTokenRequest, Jwk, Jwks, LoginRequest,
+    LoginResponse, PermissionsForAudienceRequest, TokenRequest, TokenResponse,
+};
 use crate::{CLIENT_ID_VALUE, CLIENT_SECRET_VALUE};
 
 /// .well-known/jwks.json route. This is the standard route exposed by authorities to fetch jwks
@@ -15,37 +18,38 @@ pub async fn jwks(app_data: Data<AppData>) -> HttpResponse {
         .body(serde_json::to_string(&jwks).expect("Failed to serialize JWKS to json"))
 }
 
-/// Generate a new jwt token for a given audience. All the permissions found in the local store
-/// will be included in the generated token.
-#[post("/oauth/token")]
-pub async fn jwt(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> HttpResponse {
-    let request: TokenRequest = token_request.0;
+/// Handler for json body posts to the token endpoint
+pub async fn jwt_json_body_handler(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> HttpResponse {
+    jwt(app_data, token_request.0).await
+}
 
-    if request.client_id == CLIENT_ID_VALUE && request.client_secret == CLIENT_SECRET_VALUE {
-        let permissions: Vec<String> = app_data
-            .audiences()
-            .get_permissions(&request.audience)
-            .expect("Failed to get permissions");
+/// Handler for url form encoded posts to the token endpoint
+pub async fn jwt_form_body_handler(app_data: Data<AppData>, token_request: Form<TokenRequest>) -> HttpResponse {
+    jwt(app_data, token_request.0).await
+}
 
-        let claims: Claims = Claims::new(
-            request.audience,
-            permissions,
-            app_data.config().issuer().to_string(),
-            "client_credentials".to_string(),
-        );
-
-        let random_jwk: Jwk = app_data.jwks().random_jwk().expect("Failed to get JWK");
-        let access_token: String = claims.to_string(&random_jwk).expect("Failed to generate JWT");
-        let response: TokenResponse = TokenResponse::new(access_token, None);
-
-        HttpResponse::Ok()
-            .content_type("application/json")
-            .body(serde_json::to_string(&response).expect("Failed to serialize TokenResponse"))
-    } else {
-        HttpResponse::Unauthorized()
-            .content_type("application/json")
-            .body(r#"{"error":"access_denied","error_description":"Unauthorized"}"#)
+/// Generate a new jwt token for a given audience. For `client_credentials` the audience is found in the post body
+/// and for `authorization_code` the audience is found in the authorizations cache.
+///  All the permissions found in the local store will be included in the generated token.
+async fn jwt(app_data: Data<AppData>, token_request: TokenRequest) -> HttpResponse {
+    match token_request {
+        TokenRequest::ClientCredentials(request) => jwt_for_client_credentials(app_data, request).await,
+        TokenRequest::AuthorizationCode(request) => jwt_for_authorization_code(app_data, request).await,
     }
+}
+
+/// Logs the "user" in and generates returns an auth code which can be exchanged with for a token
+#[post("/oauth/login")]
+pub async fn login(app_data: Data<AppData>, login_request: Json<LoginRequest>) -> HttpResponse {
+    let code = uuid::Uuid::new_v4().to_string();
+    app_data
+        .authorizations()
+        .put_authorization(&code, login_request.0.audience)
+        .expect("Failed to insert authorization");
+
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body(serde_json::to_string(&LoginResponse { code }).expect("Failed to serialize login response to json"))
 }
 
 /// List all audience-permissions mappings present in local implementation
@@ -107,4 +111,61 @@ pub async fn rotate_keys(app_data: Data<AppData>) -> HttpResponse {
 pub async fn revoke_keys(app_data: Data<AppData>) -> HttpResponse {
     app_data.jwks().revoke_keys().expect("Failed to revoke keys");
     HttpResponse::Ok().content_type("text/plain").body("ok")
+}
+
+pub async fn jwt_for_client_credentials(
+    app_data: Data<AppData>,
+    request: ClientCredentialsTokenRequest,
+) -> HttpResponse {
+    if request.client_id == CLIENT_ID_VALUE && request.client_secret == CLIENT_SECRET_VALUE {
+        let permissions: Vec<String> = app_data
+            .audience()
+            .get_permissions(&request.audience)
+            .expect("Failed to get permissions");
+
+        let claims: Claims = Claims::new(request.audience, permissions);
+        let random_jwk: Jwk = app_data.jwks_store().random_jwk().expect("Failed to get JWK");
+        let access_token: String = claims.to_string(&random_jwk).expect("Failed to generate JWT");
+        let response: TokenResponse = TokenResponse::new(access_token, None);
+
+        HttpResponse::Ok()
+            .content_type("application/json")
+            .body(serde_json::to_string(&response).expect("Failed to serialize TokenResponse"))
+    } else {
+        HttpResponse::Unauthorized()
+            .content_type("application/json")
+            .body(r#"{"error":"access_denied","error_description":"Unauthorized"}"#)
+    }
+}
+
+pub async fn jwt_for_authorization_code(
+    app_data: Data<AppData>,
+    request: AuthorizationCodeTokenRequest,
+) -> HttpResponse {
+    if request.client_id == CLIENT_ID_VALUE && request.client_secret == CLIENT_SECRET_VALUE {
+        let audience = app_data
+            .authorizations()
+            .get_audience_for_authorization(&request.code)
+            .expect("Failed to get audience for authorization");
+
+        let permissions: Vec<String> = app_data
+            .audience()
+            .get_permissions(&audience)
+            .expect("Failed to get permissions");
+
+        let claims: Claims = Claims::new(audience, permissions);
+
+        let random_jwk: Jwk = app_data.jwks_store().random_jwk().expect("Failed to get JWK");
+        let access_token: String = claims.to_string(&random_jwk).expect("Failed to generate JWT");
+        let response: TokenResponse = TokenResponse::new(access_token, None);
+
+        HttpResponse::Ok()
+            .content_type("application/json")
+            .body(serde_json::to_string(&response).expect("Failed to serialize TokenResponse"))
+    } else {
+        println!("Unauthorized!");
+        HttpResponse::Unauthorized()
+            .content_type("application/json")
+            .body(r#"{"error":"access_denied","error_description":"Unauthorized"}"#)
+    }
 }

--- a/src/model/app_data.rs
+++ b/src/model/app_data.rs
@@ -3,10 +3,13 @@ use crate::error::Error;
 use crate::model::audience::AudiencesStore;
 use crate::model::jwks::JwksStore;
 
+use super::authorizations::Authorizations;
+
 pub struct AppData {
     config: Config,
     audiences_store: AudiencesStore,
     jwks_store: JwksStore,
+    authorizations: Authorizations,
 }
 
 impl AppData {
@@ -15,6 +18,7 @@ impl AppData {
             config,
             audiences_store: AudiencesStore::default(),
             jwks_store: JwksStore::new()?,
+            authorizations: Authorizations::default(),
         })
     }
 
@@ -28,5 +32,9 @@ impl AppData {
 
     pub fn jwks(&self) -> &JwksStore {
         &self.jwks_store
+    }
+
+    pub fn authorizations(&self) -> &Authorizations {
+        &self.authorizations
     }
 }

--- a/src/model/authorizations.rs
+++ b/src/model/authorizations.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::error::Error;
+
+pub struct Authorizations {
+    cache: RwLock<HashMap<String, String>>,
+}
+
+impl Default for Authorizations {
+    fn default() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Authorizations {
+    pub fn get_audience_for_authorization(&self, code: &str) -> Result<String, Error> {
+        Ok(self
+            .cache
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(code)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    pub fn put_authorization(&self, code: &str, audience: String) -> Result<(), Error> {
+        self.cache
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(code.to_string(), audience);
+
+        Ok(())
+    }
+
+    pub fn all(&self) -> Result<HashMap<String, String>, Error> {
+        Ok(self.cache.read().unwrap_or_else(|p| p.into_inner()).clone())
+    }
+}

--- a/src/model/claims.rs
+++ b/src/model/claims.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
@@ -13,13 +14,13 @@ pub struct Claims {
     exp: Option<i64>,
     scope: String,
     iss: String,
-    gty: String,
+    gty: GrantType,
     #[serde(default)]
     permissions: Vec<String>,
 }
 
 impl Claims {
-    pub fn new(aud: String, permissions: Vec<String>, iss: String, gty: String) -> Self {
+    pub fn new(aud: String, permissions: Vec<String>, iss: String, gty: GrantType) -> Self {
         Self {
             aud,
             iat: Some(chrono::Utc::now().timestamp()),
@@ -67,7 +68,23 @@ impl Claims {
         &self.iss
     }
 
-    pub fn grant_type(&self) -> &str {
+    pub fn grant_type(&self) -> &GrantType {
         &self.gty
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantType {
+    ClientCredentials,
+    AuthorizationCode,
+}
+
+impl Display for GrantType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GrantType::ClientCredentials => write!(f, "client_credentials"),
+            GrantType::AuthorizationCode => write!(f, "authorization_code"),
+        }
     }
 }

--- a/src/model/jwks.rs
+++ b/src/model/jwks.rs
@@ -141,7 +141,7 @@ impl Jwk {
 mod tests {
     use crate::error::Error;
     use crate::model::jwks::JwksStore;
-    use crate::model::{Claims, Jwk, Jwks};
+    use crate::model::{Claims, GrantType, Jwk, Jwks};
 
     #[test]
     fn its_possible_to_generate_jwks_and_parse_claims_using_given_jwks_test() {
@@ -149,7 +149,7 @@ mod tests {
         let audience: &str = "audience";
         let permission: &str = "permission";
         let issuer: &str = "issuer";
-        let gty: &str = "gty";
+        let gty: GrantType = GrantType::ClientCredentials;
 
         let jwks: Jwks = jwk_store.get().unwrap();
         let random_jwk: Jwk = jwks.random_jwk().unwrap();
@@ -158,7 +158,7 @@ mod tests {
             audience.to_string(),
             vec![permission.to_string()],
             issuer.to_string(),
-            gty.to_string(),
+            gty.clone(),
         )
         .to_string(&random_jwk)
         .unwrap();
@@ -170,6 +170,6 @@ mod tests {
         assert_eq!(claims.audience(), audience);
         assert!(claims.has_permission(permission));
         assert_eq!(claims.issuer(), issuer);
-        assert_eq!(claims.grant_type(), gty);
+        assert_eq!(claims.grant_type().to_string(), gty.to_string());
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,6 +6,7 @@ pub use response::*;
 
 mod app_data;
 mod audience;
+mod authorizations;
 mod claims;
 mod jwks;
 mod request;

--- a/src/model/request.rs
+++ b/src/model/request.rs
@@ -1,15 +1,34 @@
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub struct TokenRequest {
+pub struct ClientCredentialsTokenRequest {
     pub client_id: String,
     pub client_secret: String,
     pub audience: String,
-    pub grant_type: String,
+}
+
+#[derive(Deserialize)]
+pub struct AuthorizationCodeTokenRequest {
+    pub client_id: String,
+    pub client_secret: String,
+    pub code: String,
+    pub redirect_uri: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "grant_type", rename_all = "snake_case")]
+pub enum TokenRequest {
+    AuthorizationCode(AuthorizationCodeTokenRequest),
+    ClientCredentials(ClientCredentialsTokenRequest),
 }
 
 #[derive(Deserialize)]
 pub struct PermissionsForAudienceRequest {
     pub audience: String,
     pub permissions: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub audience: String,
 }

--- a/src/model/response.rs
+++ b/src/model/response.rs
@@ -20,3 +20,8 @@ impl TokenResponse {
         }
     }
 }
+
+#[derive(Serialize)]
+pub struct LoginResponse {
+    pub code: String,
+}

--- a/web/src/pages/model.rs
+++ b/web/src/pages/model.rs
@@ -41,3 +41,19 @@ impl PermissionsForAudience {
         Self { audience, permissions }
     }
 }
+
+#[derive(serde::Serialize)]
+pub struct LoginRequest {
+    pub audience: String,
+}
+
+impl LoginRequest {
+    pub fn new(audience: String) -> Self {
+        Self { audience }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct LoginResponse {
+    pub code: String,
+}

--- a/web/src/pages/sso/mod.rs
+++ b/web/src/pages/sso/mod.rs
@@ -61,7 +61,7 @@ impl Component for SSO {
                 self.token = Some(jwt);
                 true
             }
-            Msg::CodeRecieved(code) => {
+            Msg::CodeReceived(code) => {
                 self.code = Some(code);
                 true
             }
@@ -97,11 +97,11 @@ impl Component for SSO {
                             html! { <div></div> }
                         }
                         None if Some(true) == query_params.bypass => {
-                            let () = bridge::login(ctx, |code| Msg::CodeRecieved(code), query_params.audience.clone());
+                            let () = bridge::login(ctx, |code| Msg::CodeReceived(code), query_params.audience.clone());
                             html! { <div>{"Loading.."}</div>}
                         }
                         None if self.login_pressed => {
-                            let () = bridge::login(ctx, |code| Msg::CodeRecieved(code), query_params.audience.clone());
+                            let () = bridge::login(ctx, |code| Msg::CodeReceived(code), query_params.audience.clone());
                             html! { <div>{"Loading.."}</div>}
                         }
                         None => code_login_view(ctx),

--- a/web/src/pages/sso/mod.rs
+++ b/web/src/pages/sso/mod.rs
@@ -128,6 +128,7 @@ impl Component for SSO {
     }
 }
 
+// Redirects browser directly to redirect uri
 fn token_login_view(redirect_uri: Url) -> Html {
     html! {
         <div class="form-grid">
@@ -142,6 +143,7 @@ fn token_login_view(redirect_uri: Url) -> Html {
     }
 }
 
+// When users are supported this view can collect credentials to forward to the backend, but currently no credentials are required.
 fn code_login_view(ctx: &Context<SSO>) -> Html {
     html! {
         <div class="form-grid">

--- a/web/src/pages/sso/mod.rs
+++ b/web/src/pages/sso/mod.rs
@@ -33,6 +33,8 @@ struct QueryParams {
 pub struct SSO {
     query_params_opt: Option<QueryParams>,
     token: Option<Jwt>,
+    code: Option<String>,
+    login_pressed: bool,
 }
 
 impl Component for SSO {
@@ -48,6 +50,8 @@ impl Component for SSO {
         Self {
             query_params_opt,
             token: None,
+            code: None,
+            login_pressed: false,
         }
     }
 
@@ -55,6 +59,14 @@ impl Component for SSO {
         match msg {
             Msg::TokenReceived(jwt) => {
                 self.token = Some(jwt);
+                true
+            }
+            Msg::CodeRecieved(code) => {
+                self.code = Some(code);
+                true
+            }
+            Msg::LoginPressed => {
+                self.login_pressed = true;
                 true
             }
         }
@@ -78,7 +90,22 @@ impl Component for SSO {
                         let error: String = format!("Provided response type is not valid: {}", response_type);
                         error_page(error.as_str())
                     }
-                    Ok(_) if response_type == "code" => error_page("`code` response type is not supported yet. Sorry"),
+                    Ok(url) if response_type == "code" => match self.code.clone() {
+                        Some(code) => {
+                            let url: Url = build_code_url(query_params.state.as_ref(), url, code);
+                            let _ = bindgen::redirect(url);
+                            html! { <div></div> }
+                        }
+                        None if Some(true) == query_params.bypass => {
+                            let () = bridge::login(ctx, |code| Msg::CodeRecieved(code), query_params.audience.clone());
+                            html! { <div>{"Loading.."}</div>}
+                        }
+                        None if self.login_pressed => {
+                            let () = bridge::login(ctx, |code| Msg::CodeRecieved(code), query_params.audience.clone());
+                            html! { <div>{"Loading.."}</div>}
+                        }
+                        None => code_login_view(ctx),
+                    },
                     Ok(url) => match self.token.clone() {
                         None => {
                             let () =
@@ -86,13 +113,13 @@ impl Component for SSO {
                             html! { <div>{"Loading.."}</div> }
                         }
                         Some(token) if Some(true) == query_params.bypass => {
-                            let url: Url = build_url(query_params.state.as_ref(), url, token);
+                            let url: Url = build_token_url(query_params.state.as_ref(), url, token);
                             let _ = bindgen::redirect(url);
                             html! { <div></div> }
                         }
                         Some(token) => {
-                            let url: Url = build_url(query_params.state.as_ref(), url, token);
-                            login_view(url)
+                            let url: Url = build_token_url(query_params.state.as_ref(), url, token);
+                            token_login_view(url)
                         }
                     },
                 }
@@ -101,7 +128,7 @@ impl Component for SSO {
     }
 }
 
-fn login_view(redirect_uri: Url) -> Html {
+fn token_login_view(redirect_uri: Url) -> Html {
     html! {
         <div class="form-grid">
             <div class="form-grid__row form-grid__row--small">
@@ -115,13 +142,27 @@ fn login_view(redirect_uri: Url) -> Html {
     }
 }
 
+fn code_login_view(ctx: &Context<SSO>) -> Html {
+    html! {
+        <div class="form-grid">
+            <div class="form-grid__row form-grid__row--small">
+                <div class="form-grid__row__column">
+                    <div class="button-row button-row--center">
+                        <a class="button button--primary button--huge" type="button" onclick={ctx.link().callback(|_|Msg::LoginPressed)}>{"Login"}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+}
+
 fn error_page(message: &str) -> Html {
     html! {
         <span class="title-xl-bold">{message}</span>
     }
 }
 
-fn build_url(state_opt: Option<&String>, mut url: Url, token: Jwt) -> Url {
+fn build_token_url(state_opt: Option<&String>, mut url: Url, token: Jwt) -> Url {
     let state: String = state_opt.map(|state| format!("&state={}", state)).unwrap_or_default();
 
     let access_token: String = format!(
@@ -129,6 +170,16 @@ fn build_url(state_opt: Option<&String>, mut url: Url, token: Jwt) -> Url {
         token.access_token(),
         state
     );
+
     url.set_fragment(Some(access_token.as_str()));
+    url
+}
+
+fn build_code_url(state_opt: Option<&String>, mut url: Url, code: String) -> Url {
+    let state: String = state_opt.map(|state| format!("&state={}", state)).unwrap_or_default();
+
+    let code: String = format!("code={}{}", code, state);
+
+    url.set_query(Some(code.as_str()));
     url
 }

--- a/web/src/pages/sso/msg.rs
+++ b/web/src/pages/sso/msg.rs
@@ -3,6 +3,6 @@ use crate::pages::model::Jwt;
 #[derive(Debug)]
 pub enum Msg {
     TokenReceived(Jwt),
-    CodeRecieved(String),
+    CodeReceived(String),
     LoginPressed,
 }

--- a/web/src/pages/sso/msg.rs
+++ b/web/src/pages/sso/msg.rs
@@ -3,4 +3,6 @@ use crate::pages::model::Jwt;
 #[derive(Debug)]
 pub enum Msg {
     TokenReceived(Jwt),
+    CodeRecieved(String),
+    LoginPressed,
 }


### PR DESCRIPTION
In this pr a basic implementation of a userless `authorization_code` grant is implemented for use in local dev testing.

Now, when querying the `/authorize` endpoint you can pass `response_type=code` in as a parameter and expect an authorisation code in response. 

Querying the `/oauth/token` endpoint as per the [auth code auth0 spec](https://auth0.com/docs/api/authentication?http#authorization-code-flow44) returns an access token containing all the permissions from the audience value which the user passed to `/authorize`. The endpoint still supports [client credentials](https://auth0.com/docs/api/authentication#client-credentials-flow) flow as before.


The sso frontend requests an auth code from the backend (on pressing login) and the backend caches the requested audience for a given authorization in order to map to back permissions later.

Furthermore, support for request bodies with format `application/x-www-form-urlencoded` has been added to the token endpoint as required by https://www.rfc-editor.org/rfc/rfc6749#section-4.4.2.