### PR TITLE
[PLATFORM-641]: [Localauth0] Add issuer to claims

### DIFF
--- a/localauth0.toml
+++ b/localauth0.toml
@@ -1,3 +1,5 @@
+issuer = "https://prima.localauth0.com/"
+
 [[audience]]
 name = "audience1"
 permissions = ["audience1:permission1", "audience1:permission2"]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -9,7 +9,7 @@ use crate::{CLIENT_ID_VALUE, CLIENT_SECRET_VALUE};
 /// .well-known/jwks.json route. This is the standard route exposed by authorities to fetch jwks
 #[get("/.well-known/jwks.json")]
 pub async fn jwks(app_data: Data<AppData>) -> HttpResponse {
-    let jwks: Jwks = app_data.jwks_store().get().expect("Failed to read JWKS");
+    let jwks: Jwks = app_data.jwks().get().expect("Failed to read JWKS");
     HttpResponse::Ok()
         .content_type("application/json")
         .body(serde_json::to_string(&jwks).expect("Failed to serialize JWKS to json"))
@@ -23,12 +23,12 @@ pub async fn jwt(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> 
 
     if request.client_id == CLIENT_ID_VALUE && request.client_secret == CLIENT_SECRET_VALUE {
         let permissions: Vec<String> = app_data
-            .audience()
+            .audiences()
             .get_permissions(&request.audience)
             .expect("Failed to get permissions");
 
         let claims: Claims = Claims::new(request.audience, permissions);
-        let random_jwk: Jwk = app_data.jwks_store().random_jwk().expect("Failed to get JWK");
+        let random_jwk: Jwk = app_data.jwks().random_jwk().expect("Failed to get JWK");
         let access_token: String = claims.to_string(&random_jwk).expect("Failed to generate JWT");
         let response: TokenResponse = TokenResponse::new(access_token, None);
 
@@ -46,7 +46,7 @@ pub async fn jwt(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> 
 #[get("/permissions")]
 pub async fn get_permissions(app_data: Data<AppData>) -> HttpResponse {
     let all_audiences: HashMap<String, Vec<String>> =
-        app_data.audience().all().expect("Failed to get inner audiences cache");
+        app_data.audiences().all().expect("Failed to get inner audiences cache");
 
     HttpResponse::Ok()
         .content_type("application/json")
@@ -60,7 +60,7 @@ pub async fn set_permissions_for_audience(
     permissions_for_audience_request: Json<PermissionsForAudienceRequest>,
 ) -> HttpResponse {
     app_data
-        .audience()
+        .audiences()
         .put_permissions(
             &permissions_for_audience_request.0.audience,
             permissions_for_audience_request.0.permissions,
@@ -68,7 +68,7 @@ pub async fn set_permissions_for_audience(
         .expect("Failed to put permissions for given audience");
 
     let all_audiences: HashMap<String, Vec<String>> =
-        app_data.audience().all().expect("Failed to get inner audiences cache");
+        app_data.audiences().all().expect("Failed to get inner audiences cache");
 
     HttpResponse::Ok()
         .content_type("application/json")
@@ -80,7 +80,7 @@ pub async fn set_permissions_for_audience(
 pub async fn get_permissions_by_audience(app_data: Data<AppData>, audience: Path<String>) -> HttpResponse {
     let audience: String = audience.into_inner();
     let permissions: Vec<String> = app_data
-        .audience()
+        .audiences()
         .get_permissions(audience.as_str())
         .expect("Failed to get permissions by given audience");
 
@@ -92,13 +92,13 @@ pub async fn get_permissions_by_audience(app_data: Data<AppData>, audience: Path
 /// Remove one jwk and generate new one
 #[get("/rotate")]
 pub async fn rotate_keys(app_data: Data<AppData>) -> HttpResponse {
-    app_data.jwks_store().rotate_keys().expect("Failed to rotate keys");
+    app_data.jwks().rotate_keys().expect("Failed to rotate keys");
     HttpResponse::Ok().content_type("text/plain").body("ok")
 }
 
 /// Revoke all jwks keys and generate 3 new jwks
 #[get("/revoke")]
 pub async fn revoke_keys(app_data: Data<AppData>) -> HttpResponse {
-    app_data.jwks_store().revoke_keys().expect("Failed to revoke keys");
+    app_data.jwks().revoke_keys().expect("Failed to revoke keys");
     HttpResponse::Ok().content_type("text/plain").body("ok")
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -27,7 +27,13 @@ pub async fn jwt(app_data: Data<AppData>, token_request: Json<TokenRequest>) -> 
             .get_permissions(&request.audience)
             .expect("Failed to get permissions");
 
-        let claims: Claims = Claims::new(request.audience, permissions);
+        let claims: Claims = Claims::new(
+            request.audience,
+            permissions,
+            app_data.config().issuer().to_string(),
+            "client_credentials".to_string(),
+        );
+
         let random_jwk: Jwk = app_data.jwks().random_jwk().expect("Failed to get JWK");
         let access_token: String = claims.to_string(&random_jwk).expect("Failed to generate JWT");
         let response: TokenResponse = TokenResponse::new(access_token, None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> std::io::Result<()> {
     let data: Data<AppData> = Data::new(AppData::new().expect("Failed to create AppData"));
 
     Config::load().audience().iter().for_each(|request| {
-        data.audience()
+        data.audiences()
             .put_permissions(request.name().as_str(), request.permissions().clone())
             .expect("Failed to set permissions for audience");
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use actix_web::web::Data;
 use actix_web::{middleware, App, HttpServer};
 use prima_rs_logger::GuardLoggerCell;
 
-use localauth0::config::Config;
+use localauth0::config::{Audience, Config};
 use localauth0::model::AppData;
 use localauth0::{controller, APP_NAME};
 
@@ -19,9 +19,12 @@ async fn main() -> std::io::Result<()> {
         .set(prima_rs_logger::term_guard(APP_NAME))
         .expect("Cannot set global logger guard");
 
-    let data: Data<AppData> = Data::new(AppData::new().expect("Failed to create AppData"));
+    let config: Config = Config::load();
+    let audiences: Vec<Audience> = config.audience().clone();
 
-    Config::load().audience().iter().for_each(|request| {
+    let data: Data<AppData> = Data::new(AppData::new(config).expect("Failed to create AppData"));
+
+    audiences.iter().for_each(|request| {
         data.audiences()
             .put_permissions(request.name().as_str(), request.permissions().clone())
             .expect("Failed to set permissions for audience");
@@ -38,15 +41,13 @@ async fn main() -> std::io::Result<()> {
             .service(controller::get_permissions_by_audience)
             .service(controller::rotate_keys)
             .service(controller::revoke_keys)
-            .service(
-                Files::new("/", "./web/dist")
-                    .index_file("index.html")
-                    .default_handler(|req: ServiceRequest| async {
-                        let (http_req, _payload) = req.into_parts();
-                        let response = NamedFile::open("./web/dist/index.html")?.into_response(&http_req);
-                        Ok(ServiceResponse::new(http_req, response))
-                    }),
-            )
+            .service(Files::new("/", "./web/dist").index_file("index.html").default_handler(
+                |req: ServiceRequest| async {
+                    let (http_req, _payload) = req.into_parts();
+                    let response = NamedFile::open("./web/dist/index.html")?.into_response(&http_req);
+                    Ok(ServiceResponse::new(http_req, response))
+                },
+            ))
     })
     .keep_alive(Duration::from_secs(61))
     .bind("0.0.0.0:3000")?

--- a/src/model/app_data.rs
+++ b/src/model/app_data.rs
@@ -1,25 +1,25 @@
 use crate::error::Error;
-use crate::model::audience::Audience;
+use crate::model::audience::AudiencesStore;
 use crate::model::jwks::JwksStore;
 
 pub struct AppData {
-    audience: Audience,
+    audiences_store: AudiencesStore,
     jwks_store: JwksStore,
 }
 
 impl AppData {
     pub fn new() -> Result<Self, Error> {
         Ok(Self {
-            audience: Audience::default(),
+            audiences_store: AudiencesStore::default(),
             jwks_store: JwksStore::new()?,
         })
     }
 
-    pub fn audience(&self) -> &Audience {
-        &self.audience
+    pub fn audiences(&self) -> &AudiencesStore {
+        &self.audiences_store
     }
 
-    pub fn jwks_store(&self) -> &JwksStore {
+    pub fn jwks(&self) -> &JwksStore {
         &self.jwks_store
     }
 }

--- a/src/model/app_data.rs
+++ b/src/model/app_data.rs
@@ -1,18 +1,25 @@
+use crate::config::Config;
 use crate::error::Error;
 use crate::model::audience::AudiencesStore;
 use crate::model::jwks::JwksStore;
 
 pub struct AppData {
+    config: Config,
     audiences_store: AudiencesStore,
     jwks_store: JwksStore,
 }
 
 impl AppData {
-    pub fn new() -> Result<Self, Error> {
+    pub fn new(config: Config) -> Result<Self, Error> {
         Ok(Self {
+            config,
             audiences_store: AudiencesStore::default(),
             jwks_store: JwksStore::new()?,
         })
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
     }
 
     pub fn audiences(&self) -> &AudiencesStore {

--- a/src/model/audience.rs
+++ b/src/model/audience.rs
@@ -3,11 +3,11 @@ use std::sync::RwLock;
 
 use crate::error::Error;
 
-pub struct Audience {
+pub struct AudiencesStore {
     cache: RwLock<HashMap<String, Vec<String>>>,
 }
 
-impl Default for Audience {
+impl Default for AudiencesStore {
     fn default() -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
@@ -15,7 +15,7 @@ impl Default for Audience {
     }
 }
 
-impl Audience {
+impl AudiencesStore {
     pub fn get_permissions(&self, audience: &str) -> Result<Vec<String>, Error> {
         Ok(self
             .cache

--- a/src/model/claims.rs
+++ b/src/model/claims.rs
@@ -12,19 +12,21 @@ pub struct Claims {
     iat: Option<i64>,
     exp: Option<i64>,
     scope: String,
+    iss: String,
     gty: String,
     #[serde(default)]
     permissions: Vec<String>,
 }
 
 impl Claims {
-    pub fn new(aud: String, permissions: Vec<String>) -> Self {
+    pub fn new(aud: String, permissions: Vec<String>, iss: String, gty: String) -> Self {
         Self {
             aud,
             iat: Some(chrono::Utc::now().timestamp()),
             exp: Some(chrono::Utc::now().timestamp() + 60000),
             scope: permissions.join(" "),
-            gty: "client-credentials".to_string(),
+            iss,
+            gty,
             permissions,
         }
     }
@@ -59,5 +61,13 @@ impl Claims {
 
     pub fn audience(&self) -> &str {
         &self.aud
+    }
+
+    pub fn issuer(&self) -> &str {
+        &self.iss
+    }
+
+    pub fn grant_type(&self) -> &str {
+        &self.gty
     }
 }

--- a/src/model/jwks.rs
+++ b/src/model/jwks.rs
@@ -148,13 +148,20 @@ mod tests {
         let jwk_store: JwksStore = JwksStore::new().unwrap();
         let audience: &str = "audience";
         let permission: &str = "permission";
+        let issuer: &str = "issuer";
+        let gty: &str = "gty";
 
         let jwks: Jwks = jwk_store.get().unwrap();
         let random_jwk: Jwk = jwks.random_jwk().unwrap();
 
-        let jwt: String = Claims::new(audience.to_string(), vec![permission.to_string()])
-            .to_string(&random_jwk)
-            .unwrap();
+        let jwt: String = Claims::new(
+            audience.to_string(),
+            vec![permission.to_string()],
+            issuer.to_string(),
+            gty.to_string(),
+        )
+        .to_string(&random_jwk)
+        .unwrap();
 
         let result: Result<Claims, Error> = Claims::parse(jwt.as_ref(), &[audience], &jwks);
 
@@ -162,5 +169,7 @@ mod tests {
         let claims: Claims = result.unwrap();
         assert_eq!(claims.audience(), audience);
         assert!(claims.has_permission(permission));
+        assert_eq!(claims.issuer(), issuer);
+        assert_eq!(claims.grant_type(), gty);
     }
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-641

Added `iss` field to Claims representing the issuer. Default value is set to 'https://prima.localauth0.com/'.

Added `issuer` as optional field to Config to overwrite aforementioned default
