### PR TITLE
Add support for https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added https server in addition to the current http server.
+- Made http/https port configurable in toml file (defaults are 3000/3001).
+
 ---
 
 ## [0.4.1]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "ahash",
  "base64",
@@ -143,6 +144,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "log",
+ "openssl",
+ "pin-project-lite",
+ "tokio-openssl",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +184,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "ahash",
@@ -623,10 +643,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -646,10 +719,16 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -856,6 +935,7 @@ dependencies = [
  "base64-url",
  "chrono",
  "derive-getters",
+ "futures",
  "jsonwebtoken",
  "moka",
  "openssl",
@@ -1719,6 +1799,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "winapi",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.4.1"
 
 [dependencies]
 actix-files = "0.6.0"
-actix-web = "4.0.1"
+actix-web = { version = "4", features = ["openssl"] }
 
 derive-getters = "0.2.0"
 
@@ -30,3 +30,5 @@ uuid = "1.1.2"
 toml = "0.5.9"
 
 prima_rs_logger = "0.1"
+
+futures = "0.3.21"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ In order to run localauth0 docker image execute the following:
 docker run -d -p 3000:3000 public.ecr.aws/prima/localauth0:0.3.0
 ```
 
+By default, the container exposes an http server on the port 3000 and an https one on port 3001.
+
 Note: The latest version is the same `version` written in the `Cargo.toml` file.
 
 ## APIs
@@ -113,9 +115,9 @@ The page will automatically redirect to:
 
 ## Configuration
 
-Localauth0 can be configured using a `.toml` file, which can be specified using the `LOCALAUTH0_CONFIG_PATH` 
-environment variable. Take a look [here](#Integrate-localauth0-in-existing-project) to see how to configure your 
-docker compose cluster.
+Localauth0 can be configured using a `.toml` file (see [localauth0.toml](localauth0.toml) as an example), 
+which can be specified using the `LOCALAUTH0_CONFIG_PATH` environment variable.
+Take a look [here](#Integrate-localauth0-in-existing-project) to see how to configure your docker compose cluster.
 
 ### Local development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "app:/home/app/"
     ports:
       - "3000:3000"
+      - "3001:3001"
     working_dir: /code
     environment:
       CARGO_HOME: /home/app/.cargo

--- a/localauth0.toml
+++ b/localauth0.toml
@@ -25,3 +25,9 @@ permissions = ["audience2:permission2"]
 custom_claims = [
     { name = "at_custom_claims_str", value = { String = "str" } }
 ]
+
+[http]
+port = 3000
+
+[https]
+port = 3001

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,12 @@ pub struct Config {
 
     #[serde(default)]
     access_token: AccessToken,
+
+    #[serde(default)]
+    http: Http,
+
+    #[serde(default)]
+    https: Https,
 }
 
 #[derive(Debug, Error)]
@@ -54,6 +60,8 @@ impl Config {
                     audience: vec![],
                     user: vec![],
                     access_token: Default::default(),
+                    http: Default::default(),
+                    https: Default::default(),
                 }
             }
         }
@@ -139,6 +147,32 @@ pub enum CustomFieldValue {
     Vec(Vec<String>),
 }
 
+#[derive(Debug, Deserialize, Getters)]
+pub struct Http {
+    port: u16,
+}
+
+impl Default for Http {
+    fn default() -> Self {
+        Http {
+            port: defaults::http_port(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Getters)]
+pub struct Https {
+    port: u16,
+}
+
+impl Default for Https {
+    fn default() -> Self {
+        Https {
+            port: defaults::https_port(),
+        }
+    }
+}
+
 fn log_error(error: Error) {
     match error {
         Error::VarError(_) => {
@@ -193,6 +227,9 @@ mod tests {
         custom_claims = [
             { name = "at_custom_claim_str", value = { String = "str" } }
         ]
+
+        [http]
+        port = 8000
         "#;
 
         let config: Config = toml::from_str(config_str).unwrap();
@@ -237,6 +274,9 @@ mod tests {
             .iter()
             .find(|v| v.name == "at_custom_claim_str")
             .unwrap();
-        assert_eq!(at_custom_claim.value, CustomFieldValue::String("str".to_string()))
+        assert_eq!(at_custom_claim.value, CustomFieldValue::String("str".to_string()));
+
+        assert_eq!(&8000, config.http().port());
+        assert_eq!(&3001, config.https().port());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,26 +32,28 @@ async fn main() -> std::io::Result<()> {
 }
 
 fn start_http_server(data: Data<AppData>) -> impl Future<Output = Result<(), std::io::Error>> {
+    let port = *data.config().http().port();
     HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
             .wrap(middleware::Logger::default())
             .configure(setup_service)
     })
-    .bind("0.0.0.0:3000")
+    .bind(("0.0.0.0", port))
     .unwrap()
     .keep_alive(Duration::from_secs(61))
     .run()
 }
 
 fn start_https_server(data: Data<AppData>) -> impl Future<Output = Result<(), std::io::Error>> {
+    let port = *data.config().https().port();
     HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
             .wrap(middleware::Logger::default())
             .configure(setup_service)
     })
-    .bind_openssl("0.0.0.0:3001", setup_ssl_acceptor())
+    .bind_openssl(("0.0.0.0", port), setup_ssl_acceptor())
     .expect("Cannot bind openssl socket")
     .keep_alive(Duration::from_secs(61))
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,13 @@ use actix_files::{Files, NamedFile};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::web::{self, Data};
 use actix_web::{guard, middleware, App, HttpServer};
+
+use futures::Future;
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod};
 use prima_rs_logger::GuardLoggerCell;
 
 use localauth0::config::Config;
-use localauth0::model::AppData;
+use localauth0::model::{certificates, AppData};
 use localauth0::{controller, APP_NAME};
 
 // Singleton logger. Used to free user from manually passing Logger objects around.
@@ -22,40 +25,77 @@ async fn main() -> std::io::Result<()> {
     let config: Config = Config::load();
     let data: Data<AppData> = Data::new(AppData::new(config).expect("Failed to create AppData"));
 
+    let http_server = start_http_server(data.clone());
+    let https_server = start_https_server(data.clone());
+
+    futures::try_join!(http_server, https_server).map(|_| ())
+}
+
+fn start_http_server(data: Data<AppData>) -> impl Future<Output = Result<(), std::io::Error>> {
     HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
             .wrap(middleware::Logger::default())
-            .service(controller::jwks)
-            .service(controller::get_permissions)
-            .service(controller::set_permissions_for_audience)
-            .service(controller::get_permissions_by_audience)
-            .service(controller::rotate_keys)
-            .service(controller::revoke_keys)
-            .service(controller::login)
-            .service(
-                web::resource("/oauth/token")
-                    .route(
-                        web::post()
-                            .guard(guard::Header("content-type", "application/json"))
-                            .to(controller::jwt_json_body_handler),
-                    )
-                    .route(
-                        web::post()
-                            .guard(guard::Header("content-type", "application/x-www-form-urlencoded"))
-                            .to(controller::jwt_form_body_handler),
-                    ),
-            )
-            .service(Files::new("/", "./web/dist").index_file("index.html").default_handler(
-                |req: ServiceRequest| async {
+            .configure(setup_service)
+    })
+    .bind("0.0.0.0:3000")
+    .unwrap()
+    .keep_alive(Duration::from_secs(61))
+    .run()
+}
+
+fn start_https_server(data: Data<AppData>) -> impl Future<Output = Result<(), std::io::Error>> {
+    HttpServer::new(move || {
+        App::new()
+            .app_data(data.clone())
+            .wrap(middleware::Logger::default())
+            .configure(setup_service)
+    })
+    .bind_openssl("0.0.0.0:3001", setup_ssl_acceptor())
+    .expect("Cannot bind openssl socket")
+    .keep_alive(Duration::from_secs(61))
+    .run()
+}
+
+fn setup_service(cfg: &mut web::ServiceConfig) {
+    cfg.service(controller::jwks)
+        .service(controller::get_permissions)
+        .service(controller::set_permissions_for_audience)
+        .service(controller::get_permissions_by_audience)
+        .service(controller::rotate_keys)
+        .service(controller::revoke_keys)
+        .service(controller::login)
+        .service(
+            web::resource("/oauth/token")
+                .route(
+                    web::post()
+                        .guard(guard::Header("content-type", "application/json"))
+                        .to(controller::jwt_json_body_handler),
+                )
+                .route(
+                    web::post()
+                        .guard(guard::Header("content-type", "application/x-www-form-urlencoded"))
+                        .to(controller::jwt_form_body_handler),
+                ),
+        )
+        .service(
+            Files::new("/", "./web/dist")
+                .index_file("index.html")
+                .default_handler(|req: ServiceRequest| async {
                     let (http_req, _payload) = req.into_parts();
                     let response = NamedFile::open("./web/dist/index.html")?.into_response(&http_req);
                     Ok(ServiceResponse::new(http_req, response))
-                },
-            ))
-    })
-    .keep_alive(Duration::from_secs(61))
-    .bind("0.0.0.0:3000")?
-    .run()
-    .await
+                }),
+        );
+}
+
+fn setup_ssl_acceptor() -> SslAcceptorBuilder {
+    let pkey = certificates::generate_private_key().expect("Failed to generate the private key");
+    let certificate = certificates::generate_certificate(&pkey).expect("Failed to generate the certificate");
+    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).expect("Failed to create the SSL acceptor");
+    builder.set_private_key(&pkey).expect("Error setting the private key");
+    builder
+        .set_certificate(&certificate)
+        .expect("Error setting the certificate");
+    builder
 }

--- a/src/model/certificates.rs
+++ b/src/model/certificates.rs
@@ -1,0 +1,50 @@
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::rsa::Rsa;
+use openssl::x509::extension::{BasicConstraints, KeyUsage, SubjectKeyIdentifier};
+use openssl::x509::{X509NameBuilder, X509};
+
+use crate::error::Error;
+
+pub fn generate_private_key() -> Result<PKey<Private>, Error> {
+    let rsa = Rsa::generate(2048)?;
+    let pkey = PKey::from_rsa(rsa)?;
+    Ok(pkey)
+}
+
+pub fn generate_certificate(key_pair: &PKey<Private>) -> Result<X509, Error> {
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("C", "US")?;
+    x509_name.append_entry_by_text("O", "LocalAuth0 CA")?;
+    x509_name.append_entry_by_text("CN", "LocalAuth0 CA")?;
+    let x509_name = x509_name.build();
+
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(&x509_name)?;
+    cert_builder.set_pubkey(key_pair)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+    cert_builder.append_extension(KeyUsage::new().critical().key_cert_sign().crl_sign().build()?)?;
+
+    let subject_key_identifier = SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
+    cert_builder.append_extension(subject_key_identifier)?;
+
+    cert_builder.sign(key_pair, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    Ok(cert)
+}

--- a/src/model/defaults.rs
+++ b/src/model/defaults.rs
@@ -6,6 +6,8 @@ const USER_INFO_GENDER: &str = "none";
 const USER_INFO_BIRTHDATE: &str = "2022-02-11";
 const USER_INFO_EMAIL: &str = "developers@prima.it";
 const USER_INFO_PICTURE: &str = "https://github.com/primait/localauth0/blob/6f71c9318250219a9d03fb72afe4308b8824aef7/web/assets/static/media/localauth0.png";
+const HTTP_PORT: u16 = 3000;
+const HTTPS_PORT: u16 = 3001;
 
 pub fn issuer() -> String {
     ISSUER.to_string()
@@ -37,4 +39,12 @@ pub fn user_info_email() -> String {
 
 pub fn user_info_picture() -> String {
     USER_INFO_PICTURE.to_string()
+}
+
+pub fn http_port() -> u16 {
+    HTTP_PORT
+}
+
+pub fn https_port() -> u16 {
+    HTTPS_PORT
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,7 @@ pub use user_info::*;
 mod app_data;
 mod audience;
 mod authorizations;
+pub mod certificates;
 mod claims;
 pub mod defaults;
 mod jwks;


### PR DESCRIPTION
This is an attempt for supporting https without using external proxies.

With this PR localauth0 starts both http and https servers.
The https server is started by generating a certificate on-the-fly.
The ports are configurable in the toml file; the defaults are 3000 for http (for backward compatibility) and 3001 for https.