### PR TITLE
Add missing id_token fields

### DIFF
--- a/localauth0.toml
+++ b/localauth0.toml
@@ -5,10 +5,14 @@ subject = "google-apps|developers@prima.it"
 name = "Local"
 given_name = "Locie"
 family_name = "Auth0"
+nickname = "locie.auth0"
+locale = "en"
 gender = "none"
 birthdate = "2022-02-11"
 email = "developers@prima.it"
+email_verified = true
 picture = "https://github.com/primait/localauth0/blob/6f71c9318250219a9d03fb72afe4308b8824aef7/web/assets/static/media/localauth0.png"
+updated_at = "2022-11-11T11:00:00Z"
 custom_fields = [
     { name = "roles", value = { Vec = ["fake:auth"] } }
 ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use chrono::{DateTime, Utc};
 use derive_getters::Getters;
 use prima_rs_logger::{error, info};
 use serde::Deserialize;
@@ -96,14 +97,22 @@ pub struct UserInfo {
     given_name: String,
     #[serde(default = "defaults::user_info_family_name")]
     family_name: String,
+    #[serde(default = "defaults::user_info_nickname")]
+    nickname: String,
+    #[serde(default = "defaults::user_info_locale")]
+    locale: String,
     #[serde(default = "defaults::user_info_gender")]
     gender: String,
     #[serde(default = "defaults::user_info_birthdate")]
     birthdate: String,
     #[serde(default = "defaults::user_info_email")]
     email: String,
+    #[serde(default = "defaults::user_info_email_verified")]
+    email_verified: bool,
     #[serde(default = "defaults::user_info_picture")]
     picture: String,
+    #[serde(default = "defaults::user_info_updated_at")]
+    updated_at: DateTime<Utc>,
     #[serde(default)]
     custom_fields: Vec<CustomField>,
 }
@@ -115,10 +124,14 @@ impl Default for UserInfo {
             name: defaults::user_info_name(),
             given_name: defaults::user_info_given_name(),
             family_name: defaults::user_info_family_name(),
+            nickname: defaults::user_info_nickname(),
+            locale: defaults::user_info_locale(),
             gender: defaults::user_info_gender(),
             birthdate: defaults::user_info_birthdate(),
             email: defaults::user_info_email(),
+            email_verified: defaults::user_info_email_verified(),
             picture: defaults::user_info_picture(),
+            updated_at: defaults::user_info_updated_at(),
             custom_fields: vec![],
         }
     }
@@ -192,6 +205,8 @@ fn log_error(error: Error) {
 
 #[cfg(test)]
 mod tests {
+    use chrono::DateTime;
+
     use crate::config::{Audience, Config, CustomField, CustomFieldValue};
     #[test]
     fn local_localauth0_config_file_is_loadable() {
@@ -210,10 +225,14 @@ mod tests {
         name = "name"
         given_name = "given_name"
         family_name = "family_name"
+        nickname = "nickname"
+        locale = "locale"
         gender = "gender"
         birthdate = "birthdate"
         email = "email"
+        email_verified = true
         picture = "picture"
+        updated_at = "2022-11-11T11:00:00Z"
         custom_fields = [
             { name = "custom_field_str", value = { String = "str" } },
             { name = "custom_field_vec", value = { Vec = ["vec"] } }
@@ -244,9 +263,16 @@ mod tests {
         assert_eq!(config.user_info().name, "name");
         assert_eq!(config.user_info().given_name, "given_name");
         assert_eq!(config.user_info().family_name, "family_name");
+        assert_eq!(config.user_info().nickname, "nickname");
+        assert_eq!(config.user_info().locale, "locale");
         assert_eq!(config.user_info().gender, "gender");
         assert_eq!(config.user_info().birthdate, "birthdate");
         assert_eq!(config.user_info().email, "email");
+        assert_eq!(config.user_info().email_verified, true);
+        assert_eq!(
+            config.user_info().updated_at,
+            DateTime::parse_from_rfc3339("2022-11-11T11:00:00Z").unwrap()
+        );
         assert_eq!(config.user_info().picture, "picture");
 
         assert_eq!(config.audience.len(), 2);

--- a/src/model/defaults.rs
+++ b/src/model/defaults.rs
@@ -1,12 +1,19 @@
+use chrono::{DateTime, Utc};
+
 const ISSUER: &str = "https://prima.localauth0.com/";
 const USER_INFO_SUBJECT: &str = "google-apps|developers@prima.it";
 const USER_INFO_NAME: &str = "Local";
+const USER_INFO_NICKNAME: &str = "locie.auth0";
 const USER_INFO_GIVEN_NAME: &str = "Locie";
 const USER_INFO_FAMILY_NAME: &str = "Auth0";
+const USER_INFO_LOCALE: &str = "en";
 const USER_INFO_GENDER: &str = "none";
 const USER_INFO_BIRTHDATE: &str = "2022-02-11";
 const USER_INFO_EMAIL: &str = "developers@prima.it";
+const USER_INFO_UPDATED_AT: &str = "2022-11-11T11:00:00Z";
+const USER_INFO_EMAIL_VERIFIED: bool = true;
 const USER_INFO_PICTURE: &str = "https://github.com/primait/localauth0/blob/6f71c9318250219a9d03fb72afe4308b8824aef7/web/assets/static/media/localauth0.png";
+
 const HTTP_PORT: u16 = 3000;
 const HTTPS_PORT: u16 = 3001;
 
@@ -30,6 +37,14 @@ pub fn user_info_family_name() -> String {
     USER_INFO_FAMILY_NAME.to_string()
 }
 
+pub fn user_info_nickname() -> String {
+    USER_INFO_NICKNAME.to_string()
+}
+
+pub fn user_info_locale() -> String {
+    USER_INFO_LOCALE.to_string()
+}
+
 pub fn user_info_gender() -> String {
     USER_INFO_GENDER.to_string()
 }
@@ -40,6 +55,14 @@ pub fn user_info_birthdate() -> String {
 
 pub fn user_info_email() -> String {
     USER_INFO_EMAIL.to_string()
+}
+
+pub fn user_info_email_verified() -> bool {
+    USER_INFO_EMAIL_VERIFIED
+}
+
+pub fn user_info_updated_at() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(USER_INFO_UPDATED_AT).unwrap().into()
 }
 
 pub fn user_info_picture() -> String {

--- a/src/model/id_token.rs
+++ b/src/model/id_token.rs
@@ -1,0 +1,102 @@
+use chrono::Utc;
+use serde::Serialize;
+
+use crate::config::Config;
+
+use super::UserInfo;
+
+#[derive(Debug, Serialize)]
+pub struct IdTokenClaims<'s> {
+    iss: String,
+    aud: String,
+    sid: String,
+    #[serde(flatten)]
+    user_info: UserInfo<'s>,
+    iat: Option<i64>,
+    exp: Option<i64>,
+    nonce: Option<String>,
+}
+
+impl<'s> IdTokenClaims<'s> {
+    pub fn new(config: &'s Config, audience: String, nonce: Option<String>) -> Self {
+        Self {
+            iss: config.issuer().clone(),
+            aud: audience,
+            sid: "session_id".to_string(),
+            user_info: UserInfo::new(config),
+            iat: Some(Utc::now().timestamp()),
+            exp: Some(Utc::now().timestamp() + 60000),
+            nonce,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{SecondsFormat, Utc};
+    use serde_json::{json, Value};
+
+    use crate::config::Config;
+    use crate::model::IdTokenClaims;
+
+    #[test]
+    fn id_token_serialization() {
+        let config_str: &str = r#"
+        issuer = "issuer"
+
+        [user_info]
+        subject = "subject"
+        name = "name"
+        given_name = "given_name"
+        family_name = "family_name"
+        nickname = "nickname"
+        locale = "en"
+        gender = "gender"
+        birthdate = "birthdate"
+        email = "email"
+        email_verified = true
+        picture = "picture"
+        updated_at = "2022-11-11T11:00:00Z"
+
+        [[audience]]
+        name = "audience1"
+        permissions = ["audience1:permission1", "audience1:permission2"]
+
+        [[audience]]
+        name = "audience2"
+        permissions = ["audience2:permission2"]
+        "#;
+
+        let config: Config = toml::from_str(config_str).unwrap();
+
+        let audience = "audience".to_string();
+        let nonce = Some("nonce".to_string());
+
+        let user_info: IdTokenClaims = IdTokenClaims::new(&config, audience.clone(), nonce.clone());
+        let now = Utc::now();
+        let value: Value = serde_json::to_value(user_info).unwrap();
+
+        let asserted: Value = json!({
+            "iss": config.issuer(),
+            "aud": audience,
+            "sid": "session_id",
+            "sub": config.user_info().subject(),
+            "name": config.user_info().name(),
+            "given_name": config.user_info().given_name(),
+            "family_name": config.user_info().family_name(),
+            "nickname": config.user_info().nickname(),
+            "locale": config.user_info().locale(),
+            "gender": config.user_info().gender(),
+            "birthdate": config.user_info().birthdate(),
+            "email": config.user_info().email(),
+            "email_verified": config.user_info().email_verified(),
+            "picture": config.user_info().picture(),
+            "updated_at": config.user_info().updated_at().to_rfc3339_opts(SecondsFormat::Millis, true),
+            "iat": now.timestamp(),
+            "exp": now.timestamp() + 60000,
+            "nonce": nonce,
+        });
+
+        assert_eq!(value, asserted);
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,5 +1,6 @@
 pub use app_data::*;
 pub use claims::*;
+pub use id_token::*;
 pub use jwks::*;
 pub use request::*;
 pub use response::*;
@@ -11,6 +12,7 @@ mod authorizations;
 pub mod certificates;
 mod claims;
 pub mod defaults;
+mod id_token;
 mod jwks;
 mod request;
 mod response;

--- a/src/model/request.rs
+++ b/src/model/request.rs
@@ -12,6 +12,7 @@ pub struct AuthorizationCodeTokenRequest {
     pub client_id: String,
     pub client_secret: String,
     pub code: String,
+    pub nonce: Option<String>,
     pub redirect_uri: Option<String>,
 }
 


### PR DESCRIPTION
This PR aims to add all the `id_token` fields returned by the actual Auth0. The following is an example of an `id_token` (I masked the sensible fields):
```json
{
    "given_name": "Luca ",
    "family_name": "Iachini",
    "nickname": "luca.iachini",
    "name": "Luca Iachini",
    "picture": "https://lh3.googleusercontent.com/a/<image_id>",
    "locale": "it",
    "updated_at": "2022-11-02T12:24:05.399Z",
    "email": "luca.iachini@prima.it",
    "email_verified": true,
    "iss": "https://auth0.com/",
    "sub": "google-oauth2|<google_id>",
    "aud": "<client_d>",
    "iat": 1667391859,
    "exp": 1667427859,
    "sid": "<session_id>",
    "nonce": "<random_nonce>"
}
```

This PR also introduces the [nonce exchange for the Code flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/mitigate-replay-attacks-when-using-the-implicit-flow).