### PR TITLE
Hardcode aws account id

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID_SHARED_SERVICES_PRODUCTION }}:role/oidc-github-ecr-localauth0
+          role-to-assume: arn:aws:iam::193543784330:role/oidc-github-ecr-localauth0
           aws-region: eu-west-1
 
       - name: Login to public ECR


### PR DESCRIPTION
We can't use variables for public repos