### PR TITLE
Allow manual trigger on the CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,12 @@ name: CD
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "The tag name to use"
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,7 +41,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -50,5 +56,5 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: "public.ecr.aws/prima/localauth0:${{ github.event.release.tag_name }}"
+          tags: "public.ecr.aws/prima/localauth0:${{ inputs.tag_name || github.event.release.tag_name }}"
           file: "Dockerfile_localauth0"


### PR DESCRIPTION
This is mainly to test the CD workflow without needing to modify the aws iam policy
