### PR TITLE
Use the correct version of the aws credentials workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::193543784330:role/oidc-github-ecr-localauth0
           aws-region: eu-west-1


### PR DESCRIPTION
Turns out aws is using a depracated version of their own aws sdk...