### PR TITLE
Use correct binaries in the dockerfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: cargo build --release
       - name: Build web
-        run: trunk build web/index.html
+        run: trunk build --release web/index.html
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "localauth0"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Dockerfile_localauth0
+++ b/Dockerfile_localauth0
@@ -9,7 +9,7 @@ RUN apt-get update && \
   apt-get clean && \
   apt-get autoremove
 
-COPY target/debug/localauth0 /localauth0
+COPY target/release/localauth0 /localauth0
 COPY web/dist /web/dist
 
 ENTRYPOINT ["/localauth0"]


### PR DESCRIPTION
Long term we should minimize the dockerfile by building a static musl based binary and using a scratch/alpine container
