### PR TITLE
[PLATFORM-1213]: Migrate CI to GHA

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,6 +55,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: "public.ecr.aws/prima/localauth0:${{ inputs.tag_name || github.event.release.tag_name }}"
+          tags: "public.ecr.aws/c6i9l4r6/localauth0:${{ inputs.tag_name || github.event.release.tag_name }}"
           context: .
           file: "Dockerfile_localauth0"


### PR DESCRIPTION
The new url is: public.ecr.aws/c6i9l4r6/localauth0, for testing I'm not updating any of the urls in the docs, I'll try to create a public.ecr.aws/localauth0/localauth0 alias, but for now I'd like to make sure this deploys

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1213

