### PR TITLE
add digitalSignature usage to the key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+---
+
+## [0.8.1] - 2024-10-17
+
 # Fixed
 
 - Chrome ERR_SSL_KEY_USAGE_INCOMPATIBLE due to the key usage not being configured.
@@ -188,7 +192,9 @@ Note: images temporairly use the public.ecr.aws/c6i9l4r6/localauth0 registry.
 
 - First release 🎉
 
-[Unreleased]: https://github.com/primait/localauth0/compare/0.8.0...HEAD
+
+[Unreleased]: https://github.com/primait/localauth0/compare/0.8.1...HEAD
+[0.8.1]: https://github.com/primait/localauth0/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/primait/localauth0/compare/0.7.2...0.8.0
 [0.7.2]: https://github.com/primait/localauth0/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/primait/localauth0/compare/0.7.0...0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+# Fixed
+
+- Chrome ERR_SSL_KEY_USAGE_INCOMPATIBLE due to the key usage not being configured.
+
 ---
 
 ## [0.8.0] - 2024-08-28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "localauth0"
-version = "0.8.0"
+version = "0.8.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tenant and test it offline for "real".
 In order to run localauth0 docker image execute the following:
 
 ```shell
-docker run -d -p 3000:3000 public.ecr.aws/primaassicurazioni/localauth0:0.8.0
+docker run -d -p 3000:3000 public.ecr.aws/primaassicurazioni/localauth0:0.8.1
 ```
 
 By default, the container exposes an http server on the port 3000 and an https
@@ -247,7 +247,7 @@ Add this snippet to your `docker-compose.yml` file and reference it in your app
 
 ```yaml
 auth0:
-  image: public.ecr.aws/primaassicurazioni/localauth0:0.8.0
+  image: public.ecr.aws/primaassicurazioni/localauth0:0.8.1
   healthcheck:
     test: ["CMD", "/localauth0", "healthcheck"]
   ports:

--- a/src/model/certificates.rs
+++ b/src/model/certificates.rs
@@ -38,7 +38,14 @@ pub fn generate_certificate(key_pair: &PKey<Private>) -> Result<X509, Error> {
     cert_builder.set_not_after(&not_after)?;
 
     cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
-    cert_builder.append_extension(KeyUsage::new().critical().key_cert_sign().crl_sign().digital_signature().build()?)?;
+    cert_builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .key_cert_sign()
+            .crl_sign()
+            .digital_signature()
+            .build()?,
+    )?;
 
     let subject_key_identifier = SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
     cert_builder.append_extension(subject_key_identifier)?;

--- a/src/model/certificates.rs
+++ b/src/model/certificates.rs
@@ -38,7 +38,7 @@ pub fn generate_certificate(key_pair: &PKey<Private>) -> Result<X509, Error> {
     cert_builder.set_not_after(&not_after)?;
 
     cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
-    cert_builder.append_extension(KeyUsage::new().critical().key_cert_sign().crl_sign().build()?)?;
+    cert_builder.append_extension(KeyUsage::new().critical().key_cert_sign().crl_sign().digital_signature().build()?)?;
 
     let subject_key_identifier = SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
     cert_builder.append_extension(subject_key_identifier)?;


### PR DESCRIPTION
This is a requirement for self-signed certificates.

Google Chrome aborts the connection with a `ERR_SSL_KEY_USAGE_INCOMPATIBLE` message if the key usage is not properly configured.

See: https://superuser.com/a/1466118/83567