### PR TITLE
sso: make `connection' query param optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Changed unused `connection` query parameter to be optional.
+
 ---
 
 ## [0.8.1] - 2024-10-17

--- a/web/src/pages/sso/mod.rs
+++ b/web/src/pages/sso/mod.rs
@@ -13,14 +13,14 @@ mod msg;
 
 const MISSING_PARAMS_CONTENT: &str = "Bad request while authenticating with sso:\
 Missing some query params.\
-Mandatory query params are: `client_id`, `connection`, audience`, `redirect_uri`, `scope` and `response_type`\
-Optional query params are: `state` and `bypass`";
+Mandatory query params are: `client_id`, audience`, `redirect_uri`, `scope` and `response_type`\
+Optional query params are: `connection`, `state` and `bypass`";
 
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct QueryParams {
     client_id: String,
-    connection: String,
+    connection: Option<String>,
     audience: String,
     redirect_uri: String,
     scope: String,


### PR DESCRIPTION
The parameter is not required (see: https://auth0.com/docs/api/authentication#social) and the localauth0 API can be made slightly more forgiving (useful as for some reason our auth0 library is unable to add this extra `connection` parameter).

Also a version release with this change would be amazing.