### PR TITLE
ci: allow PRs to run from external contributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,15 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   lint:
-    # Avoid duplicate jobs on PR from a branch on the same repo
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,8 +36,6 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
   test:
-    # Avoid duplicate jobs on PR from a branch on the same repo
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
     # https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f
 
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - lint


### PR DESCRIPTION
For some reason we made it so external contributions' workflows wouldn't run, but reading [here](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks) first time contributors still need to be approved so there shouldn't be any security issues (see [here on Slack](https://prima.slack.com/archives/C07675FAYDB/p1748514598532199) for confirmation from security)