### PR TITLE
Pin `trunk` to a version that works with rust 1.80.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY entrypoint /code/entrypoint
 USER app
 
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install --locked trunk
+RUN cargo install --locked trunk --version 0.21.5
 
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
Alternatively, we could bump the version of rust that this image derives from, but it seems like the version of `trunk` should be pinned regardless to prevent its requirements from breaking the Dockerfile unexpectedly.