### PR TITLE
Resolve Issue #118 - Endpoint Handlers not Registered for Custom Claims & User Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to
 
 ---
 
+## [0.9.1] - 2026-06-19
+
+### Fixed
+
+- Actually register `(get|set)_custom_claims` and `(get|set)_user_info`,
+  addressing issue [#118](https://github.com/primait/localauth0/issues/118)
+
+---
+
 ## [0.9.0] - 2026-05-08
 
 ### Changed
@@ -222,7 +231,8 @@ Note: images temporairly use the public.ecr.aws/c6i9l4r6/localauth0 registry.
 
 - First release 🎉
 
-[Unreleased]: https://github.com/primait/localauth0/compare/0.9.0...HEAD
+[Unreleased]: https://github.com/primait/localauth0/compare/0.9.1...HEAD
+[0.9.1]: https://github.com/primait/localauth0/compare/0.9.0...0.9.1
 [0.9.0]: https://github.com/primait/localauth0/compare/0.8.3...0.9.0
 [0.8.3]: https://github.com/primait/localauth0/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/primait/localauth0/compare/0.8.1...0.8.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "localauth0"
-version = "0.9.0"
+version = "0.9.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tenant and test it offline for "real".
 In order to run localauth0 docker image execute the following:
 
 ```shell
-docker run -d -p 3000:3000 public.ecr.aws/primaassicurazioni/localauth0:0.9.0
+docker run -d -p 3000:3000 public.ecr.aws/primaassicurazioni/localauth0:0.9.1
 ```
 
 By default, the container exposes an http server on the port 3000 and an https
@@ -248,7 +248,7 @@ Add this snippet to your `docker-compose.yml` file and reference it in your app
 
 ```yaml
 auth0:
-  image: public.ecr.aws/primaassicurazioni/localauth0:0.9.0
+  image: public.ecr.aws/primaassicurazioni/localauth0:0.9.1
   healthcheck:
     test: ["CMD", "/localauth0", "healthcheck"]
   ports:

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,34 +150,21 @@ mod tests {
         let config = Config::load_or_default();
         let app_data = Data::new(AppData::new(&config).expect("Failed to create AppData"));
 
-        let app = test::init_service(
-            App::new()
-                .app_data(app_data)
-                .configure(setup_service),
-        )
-        .await;
+        let app = test::init_service(App::new().app_data(app_data).configure(setup_service)).await;
 
-        let req = test::TestRequest::get()
-            .uri("/oauth/token/custom_claims")
-            .to_request();
+        let req = test::TestRequest::get().uri("/oauth/token/custom_claims").to_request();
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), 404, "Custom claims GET endpoint not registered");
 
-        let req = test::TestRequest::post()
-            .uri("/oauth/token/custom_claims")
-            .to_request();
+        let req = test::TestRequest::post().uri("/oauth/token/custom_claims").to_request();
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), 404, "Custom claims POST endpoint not registered");
 
-        let req = test::TestRequest::get()
-            .uri("/oauth/token/user_info")
-            .to_request();
+        let req = test::TestRequest::get().uri("/oauth/token/user_info").to_request();
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), 404, "User info GET endpoint not registered");
 
-        let req = test::TestRequest::post()
-            .uri("/oauth/token/user_info")
-            .to_request();
+        let req = test::TestRequest::post().uri("/oauth/token/user_info").to_request();
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), 404, "User info POST endpoint not registered");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,10 @@ fn setup_service(cfg: &mut web::ServiceConfig) {
         .service(controller::get_permissions)
         .service(controller::set_permissions_for_audience)
         .service(controller::get_permissions_by_audience)
+        .service(controller::get_custom_claims)
+        .service(controller::set_custom_claims)
+        .service(controller::get_user_info)
+        .service(controller::set_user_info)
         .service(controller::rotate_keys)
         .service(controller::revoke_keys)
         .service(controller::login)
@@ -134,4 +138,47 @@ fn setup_ssl_acceptor() -> SslAcceptorBuilder {
         .set_certificate(&certificate)
         .expect("Error setting the certificate");
     builder
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, App};
+
+    #[actix_web::test]
+    async fn test_setup_service_registers_all_handlers() {
+        let config = Config::load_or_default();
+        let app_data = Data::new(AppData::new(&config).expect("Failed to create AppData"));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(app_data)
+                .configure(setup_service),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/oauth/token/custom_claims")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_ne!(resp.status(), 404, "Custom claims GET endpoint not registered");
+
+        let req = test::TestRequest::post()
+            .uri("/oauth/token/custom_claims")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_ne!(resp.status(), 404, "Custom claims POST endpoint not registered");
+
+        let req = test::TestRequest::get()
+            .uri("/oauth/token/user_info")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_ne!(resp.status(), 404, "User info GET endpoint not registered");
+
+        let req = test::TestRequest::post()
+            .uri("/oauth/token/user_info")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_ne!(resp.status(), 404, "User info POST endpoint not registered");
+    }
 }


### PR DESCRIPTION
Resolves  - #118 

The controller endpoint handlers were not registered, resulting in 405 errors when attempting to send requests to those endpoints. 

Added tests to verify that all handlers were registered in `main.rs`. Verified the tests pass by running the following commands:

`docker run -d -p 3000:3000 -v .:/code --name localauth0-dev localauth0 "sleep infinity"`
`docker exec localauth0-dev cargo test`